### PR TITLE
export VAULT_ADDR in secrets.txt

### DIFF
--- a/scripts/welcome.sh
+++ b/scripts/welcome.sh
@@ -43,7 +43,7 @@ cat <<EOF > /vagrant/secrets.txt
 # concourse-main-username: ${concourse_username}
 # concourse-main-password: ${concourse_password}
 
-VAULT_ADDR="http://${external_ip}:8200"
+export VAULT_ADDR="http://${external_ip}:8200"
 
 vault kv put /concourse/main/minio-endpoint       value=${s3_endpoint}
 vault kv put /concourse/main/s3-access-key-id     value=${s3_access_key}


### PR DESCRIPTION
In order to work reliably, the environment variable VAULT_ADDR has to be
exported to that it is accessible in the child processes started by the
following invocations of the `vault` command.

The issue is when invoking the following command, as suggested in the
README:

```
sh secrets.txt
```

Output:

```
Get https://127.0.0.1:8200/v1/sys/internal/ui/mounts/concourse/main/minio-endpoint: http: server gave HTTP response to HTTPS client
Get https://127.0.0.1:8200/v1/sys/internal/ui/mounts/concourse/main/s3-access-key-id: http: server gave HTTP response to HTTPS client
Get https://127.0.0.1:8200/v1/sys/internal/ui/mounts/concourse/main/s3-secret-access-key: http: server gave HTTP response to HTTPS client
```

Output after this fix:

```
Success! Data written to: concourse/main/minio-endpoint
Success! Data written to: concourse/main/s3-access-key-id
Success! Data written to: concourse/main/s3-secret-access-key
```
Tested on linux where the `sh` shell resolves to POSIX-compliant `dash`.